### PR TITLE
Interpolates electron temperature from look-up table

### DIFF
--- a/Code/Chemistry.m
+++ b/Code/Chemistry.m
@@ -1617,6 +1617,7 @@ function [derivatives, thermalModel] = kinetics(time, variables, directRateCoeff
         case 'localField'
           lookUpXValues = chemistry.lookUpTableRedFieldValues;
           lookUpQueryPoint = workCond.reducedField;
+          workCond.electronTemperature = interp1(lookUpXValues, chemistry.lookUpTableEleTempValues, lookUpQueryPoint);
         case 'localEnergy'
           lookUpXValues = chemistry.lookUpTableEleTempValues;
           lookUpQueryPoint = workCond.electronTemperature;


### PR DESCRIPTION
Correctly interpolates the electron temperature from the reduced field lookup table when using the 'localField' approximation. This ensures the `electronTemperature` is properly set, resolving a bug in quasi-stationary simulations.

Fixes #34
